### PR TITLE
Handle caching and easing of the rows affected value used for .Count()

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,17 @@ func (c *dummyCacher) init() {
 	}
 }
 
-func (c *dummyCacher) Get(key string) interface{} {
+func (c *dummyCacher) Get(key string) *caches.Query {
 	c.init()
-	val, _ := c.store.Load(key)
-	return val
+	val, ok := c.store.Load(key)
+	if !ok {
+		return nil
+	}
+
+	return val.(*caches.Query)
 }
 
-func (c *dummyCacher) Store(key string, val interface{}) error {
+func (c *dummyCacher) Store(key string, val *caches.Query) error {
 	c.init()
 	c.store.Store(key, val)
 	return nil

--- a/cacher.go
+++ b/cacher.go
@@ -1,6 +1,6 @@
 package caches
 
 type Cacher interface {
-	Get(key string) interface{}
-	Store(key string, val interface{}) error
+	Get(key string) *Query
+	Store(key string, val *Query) error
 }

--- a/cacher_test.go
+++ b/cacher_test.go
@@ -15,13 +15,17 @@ func (c *cacherMock) init() {
 	}
 }
 
-func (c *cacherMock) Get(key string) interface{} {
+func (c *cacherMock) Get(key string) *Query {
 	c.init()
-	val, _ := c.store.Load(key)
-	return val
+	val, ok := c.store.Load(key)
+	if !ok {
+		return nil
+	}
+
+	return val.(*Query)
 }
 
-func (c *cacherMock) Store(key string, val interface{}) error {
+func (c *cacherMock) Store(key string, val *Query) error {
 	c.init()
 	c.store.Store(key, val)
 	return nil
@@ -37,12 +41,16 @@ func (c *cacherStoreErrorMock) init() {
 	}
 }
 
-func (c *cacherStoreErrorMock) Get(key string) interface{} {
+func (c *cacherStoreErrorMock) Get(key string) *Query {
 	c.init()
-	val, _ := c.store.Load(key)
-	return val
+	val, ok := c.store.Load(key)
+	if !ok {
+		return nil
+	}
+
+	return val.(*Query)
 }
 
-func (c *cacherStoreErrorMock) Store(key string, val interface{}) error {
+func (c *cacherStoreErrorMock) Store(string, *Query) error {
 	return errors.New("store-error")
 }

--- a/caches_test.go
+++ b/caches_test.go
@@ -16,10 +16,6 @@ type mockDest struct {
 	Result string
 }
 
-type mockDestWithUnexportedField struct {
-	result string
-}
-
 func TestCaches_Name(t *testing.T) {
 	caches := &Caches{
 		Conf: &Config{
@@ -170,48 +166,6 @@ func TestCaches_Query(t *testing.T) {
 		})
 
 		t.Run("two identical queries", func(t *testing.T) {
-			//t.Run("with error", func(t *testing.T) {
-			//	var incr int32
-			//	db1, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
-			//	db1.Statement.Dest = &mockDestWithUnexportedField{}
-			//	db2, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
-			//	db2.Statement.Dest = &mockDestWithUnexportedField{}
-			//
-			//	caches := &Caches{
-			//		Conf: conf,
-			//
-			//		queue: &sync.Map{},
-			//		queryCb: func(db *gorm.DB) {
-			//			time.Sleep(1 * time.Second)
-			//			atomic.AddInt32(&incr, 1)
-			//
-			//			db.Statement.Dest.(*mockDestWithUnexportedField).result = fmt.Sprintf("%d", atomic.LoadInt32(&incr))
-			//		},
-			//	}
-			//
-			//	// Set the queries' SQL into something specific
-			//	exampleQuery := "demo-query"
-			//	db1.Statement.SQL.WriteString(exampleQuery)
-			//	db2.Statement.SQL.WriteString(exampleQuery)
-			//
-			//	wg := &sync.WaitGroup{}
-			//	wg.Add(2)
-			//	go func() {
-			//		caches.Query(db1) // Execute the query
-			//		wg.Done()
-			//	}()
-			//	go func() {
-			//		time.Sleep(500 * time.Millisecond) // Execute the second query half a second later
-			//		caches.Query(db2)                  // Execute the query
-			//		wg.Done()
-			//	}()
-			//	wg.Wait()
-			//
-			//	if db2.Error == nil {
-			//		t.Error("an error was expected, got none")
-			//	}
-			//})
-
 			t.Run("without error", func(t *testing.T) {
 				var incr int32
 				db1, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
@@ -424,7 +378,6 @@ func TestCaches_Query(t *testing.T) {
 		})
 
 		t.Run("two different queries", func(t *testing.T) {
-
 			var incr int32
 			db1, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
 			db1.Statement.Dest = &mockDest{}

--- a/query.go
+++ b/query.go
@@ -1,0 +1,13 @@
+package caches
+
+import "gorm.io/gorm"
+
+type Query struct {
+	Dest         interface{}
+	RowsAffected int64
+}
+
+func (q *Query) replaceOn(db *gorm.DB) {
+	SetPointedValue(db.Statement.Dest, q.Dest)
+	SetPointedValue(&db.Statement.RowsAffected, &q.RowsAffected)
+}


### PR DESCRIPTION
- [x] Do only one thing
- [-] Non breaking API changes
- [-] Tested

### What did this pull request do?

Handle caching and easing of the rows affected value used for .Count()

### User Case Description

Fixing https://github.com/go-gorm/caches/issues/2
