### PR TITLE
Implemented query marshalling to help with remote caching

### DIFF
--- a/cacher.go
+++ b/cacher.go
@@ -1,6 +1,14 @@
 package caches
 
+import (
+	"context"
+)
+
 type Cacher interface {
-	Get(key string) *Query
-	Store(key string, val *Query) error
+	// Get impl should check if a specific key exists in the cache and return its value
+	// look at Query.Marshal
+	Get(ctx context.Context, key string, q *Query[any]) (*Query[any], error)
+	// Store is supposed to store a cached representation of the val param
+	// look at Query.Unmarshal
+	Store(ctx context.Context, key string, val *Query[any]) error
 }

--- a/cacher_test.go
+++ b/cacher_test.go
@@ -1,6 +1,7 @@
 package caches
 
 import (
+	"context"
 	"errors"
 	"sync"
 )
@@ -15,42 +16,38 @@ func (c *cacherMock) init() {
 	}
 }
 
-func (c *cacherMock) Get(key string) *Query {
+func (c *cacherMock) Get(_ context.Context, key string, _ *Query[any]) (*Query[any], error) {
 	c.init()
 	val, ok := c.store.Load(key)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
-	return val.(*Query)
+	return val.(*Query[any]), nil
 }
 
-func (c *cacherMock) Store(key string, val *Query) error {
+func (c *cacherMock) Store(_ context.Context, key string, val *Query[any]) error {
 	c.init()
 	c.store.Store(key, val)
 	return nil
 }
 
-type cacherStoreErrorMock struct {
-	store *sync.Map
+type cacherStoreErrorMock struct{}
+
+func (c *cacherStoreErrorMock) Get(context.Context, string, *Query[any]) (*Query[any], error) {
+	return nil, nil
 }
 
-func (c *cacherStoreErrorMock) init() {
-	if c.store == nil {
-		c.store = &sync.Map{}
-	}
-}
-
-func (c *cacherStoreErrorMock) Get(key string) *Query {
-	c.init()
-	val, ok := c.store.Load(key)
-	if !ok {
-		return nil
-	}
-
-	return val.(*Query)
-}
-
-func (c *cacherStoreErrorMock) Store(string, *Query) error {
+func (c *cacherStoreErrorMock) Store(context.Context, string, *Query[any]) error {
 	return errors.New("store-error")
+}
+
+type cacherGetErrorMock struct{}
+
+func (c *cacherGetErrorMock) Get(context.Context, string, *Query[any]) (*Query[any], error) {
+	return nil, errors.New("get-error")
+}
+
+func (c *cacherGetErrorMock) Store(context.Context, string, *Query[any]) error {
+	return nil
 }

--- a/caches_test.go
+++ b/caches_test.go
@@ -272,32 +272,59 @@ func TestCaches_Query(t *testing.T) {
 	t.Run("cacher only", func(t *testing.T) {
 		t.Run("one query", func(t *testing.T) {
 			t.Run("with error", func(t *testing.T) {
-				db, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
-				db.Statement.Dest = &mockDest{}
+				t.Run("store", func(t *testing.T) {
+					db, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
+					db.Statement.Dest = &mockDest{}
 
-				caches := &Caches{
-					Conf: &Config{
-						Easer:  false,
-						Cacher: &cacherStoreErrorMock{},
-					},
+					caches := &Caches{
+						Conf: &Config{
+							Easer:  false,
+							Cacher: &cacherStoreErrorMock{},
+						},
 
-					queue: &sync.Map{},
-					queryCb: func(db *gorm.DB) {
-						db.Statement.Dest.(*mockDest).Result = db.Statement.SQL.String()
-					},
-				}
+						queue: &sync.Map{},
+						queryCb: func(db *gorm.DB) {
+							db.Statement.Dest.(*mockDest).Result = db.Statement.SQL.String()
+						},
+					}
 
-				// Set the query SQL into something specific
-				exampleQuery := "demo-query"
-				db.Statement.SQL.WriteString(exampleQuery)
+					// Set the query SQL into something specific
+					exampleQuery := "demo-query"
+					db.Statement.SQL.WriteString(exampleQuery)
 
-				caches.Query(db) // Execute the query
+					caches.Query(db) // Execute the query
 
-				if db.Error == nil {
-					t.Error("an error was expected, got none")
-				}
+					if db.Error == nil {
+						t.Error("an error was expected, got none")
+					}
+				})
+				t.Run("get", func(t *testing.T) {
+					db, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
+					db.Statement.Dest = &mockDest{}
+
+					caches := &Caches{
+						Conf: &Config{
+							Easer:  false,
+							Cacher: &cacherGetErrorMock{},
+						},
+
+						queue: &sync.Map{},
+						queryCb: func(db *gorm.DB) {
+							db.Statement.Dest.(*mockDest).Result = db.Statement.SQL.String()
+						},
+					}
+
+					// Set the query SQL into something specific
+					exampleQuery := "demo-query"
+					db.Statement.SQL.WriteString(exampleQuery)
+
+					caches.Query(db) // Execute the query
+
+					if db.Error == nil {
+						t.Error("an error was expected, got none")
+					}
+				})
 			})
-
 			t.Run("without error", func(t *testing.T) {
 				db, _ := gorm.Open(tests.DummyDialector{}, &gorm.Config{})
 				db.Statement.Dest = &mockDest{}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
-module github.com/go-gorm/caches/v2
+module github.com/go-gorm/caches/v3
 
-go 1.16
+go 1.18
 
 require gorm.io/gorm v1.25.0
+
+require (
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+)

--- a/query.go
+++ b/query.go
@@ -1,10 +1,22 @@
 package caches
 
-import "gorm.io/gorm"
+import (
+	"encoding/json"
+
+	"gorm.io/gorm"
+)
 
 type Query struct {
 	Dest         interface{}
 	RowsAffected int64
+}
+
+func (q *Query) Marshal() ([]byte, error) {
+	return json.Marshal(q)
+}
+
+func (q *Query) Unmarshal(bytes []byte) error {
+	return json.Unmarshal(bytes, q)
 }
 
 func (q *Query) replaceOn(db *gorm.DB) {

--- a/query.go
+++ b/query.go
@@ -6,20 +6,20 @@ import (
 	"gorm.io/gorm"
 )
 
-type Query struct {
-	Dest         interface{}
+type Query[T any] struct {
+	Dest         T
 	RowsAffected int64
 }
 
-func (q *Query) Marshal() ([]byte, error) {
+func (q *Query[T]) Marshal() ([]byte, error) {
 	return json.Marshal(q)
 }
 
-func (q *Query) Unmarshal(bytes []byte) error {
+func (q *Query[T]) Unmarshal(bytes []byte) error {
 	return json.Unmarshal(bytes, q)
 }
 
-func (q *Query) replaceOn(db *gorm.DB) {
+func (q *Query[T]) replaceOn(db *gorm.DB) {
 	SetPointedValue(db.Statement.Dest, q.Dest)
 	SetPointedValue(&db.Statement.RowsAffected, &q.RowsAffected)
 }

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,92 @@
+package caches
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestQuery(t *testing.T) {
+	t.Run("replaceOn", func(t *testing.T) {
+		db := &gorm.DB{
+			Statement: &gorm.Statement{
+				DB: &gorm.DB{},
+				Dest: &struct {
+					Name string
+					gorm.Model
+				}{},
+			},
+		}
+
+		expectedDestValue := &struct {
+			Name string
+			gorm.Model
+		}{
+			Name: "ktsivkov",
+		}
+		expectedAffectedRows := int64(2)
+
+		query := Query{
+			Dest:         expectedDestValue,
+			RowsAffected: expectedAffectedRows,
+		}
+		query.replaceOn(db)
+
+		if !reflect.DeepEqual(db.Statement.Dest, expectedDestValue) {
+			t.Fatalf("replaceOn was expected to replace the destination value with the one contained inside the query.")
+		}
+
+		if !reflect.DeepEqual(db.Statement.RowsAffected, expectedAffectedRows) {
+			t.Fatalf("replaceOn was expected to replace the affected rows value with the one contained inside the query.")
+		}
+	})
+
+	t.Run("Marshal", func(t *testing.T) {
+		query := Query{
+			Dest: &struct {
+				Name string
+				gorm.Model
+			}{
+				Name: "ktsivkov",
+			},
+			RowsAffected: 2,
+		}
+		res, err := query.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal resulted to an unexpected error. %v", err)
+		}
+
+		if !json.Valid(res) {
+			t.Fatalf("Marshal returned an invalid json result. %v", err)
+		}
+	})
+	t.Run("Unmarshal", func(t *testing.T) {
+		marshalled := "{\"Dest\":{\"Name\":\"ktsivkov\",\"ID\":0,\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"UpdatedAt\":\"0001-01-01T00:00:00Z\",\"DeletedAt\":null},\"RowsAffected\":2}"
+		expected := Query{
+			Dest: &struct {
+				Name string
+				gorm.Model
+			}{
+				Name: "ktsivkov",
+			},
+			RowsAffected: 2,
+		}
+		query := Query{
+			Dest: &struct {
+				Name string
+				gorm.Model
+			}{},
+			RowsAffected: 0,
+		}
+		err := query.Unmarshal([]byte(marshalled))
+		if err != nil {
+			t.Fatalf("Unmarshal resulted to an unexpected error. %v", err)
+		}
+
+		if !reflect.DeepEqual(expected, query) {
+			t.Fatalf("Unmarshal was expected to shape the query into the expected, but failed.")
+		}
+	})
+}

--- a/query_test.go
+++ b/query_test.go
@@ -10,25 +10,23 @@ import (
 
 func TestQuery(t *testing.T) {
 	t.Run("replaceOn", func(t *testing.T) {
+		type User struct {
+			Name string
+			gorm.Model
+		}
 		db := &gorm.DB{
 			Statement: &gorm.Statement{
-				DB: &gorm.DB{},
-				Dest: &struct {
-					Name string
-					gorm.Model
-				}{},
+				DB:   &gorm.DB{},
+				Dest: &User{},
 			},
 		}
 
-		expectedDestValue := &struct {
-			Name string
-			gorm.Model
-		}{
+		expectedDestValue := &User{
 			Name: "ktsivkov",
 		}
 		expectedAffectedRows := int64(2)
 
-		query := Query{
+		query := Query[*User]{
 			Dest:         expectedDestValue,
 			RowsAffected: expectedAffectedRows,
 		}
@@ -44,11 +42,12 @@ func TestQuery(t *testing.T) {
 	})
 
 	t.Run("Marshal", func(t *testing.T) {
-		query := Query{
-			Dest: &struct {
-				Name string
-				gorm.Model
-			}{
+		type User struct {
+			Name string
+			gorm.Model
+		}
+		query := Query[User]{
+			Dest: User{
 				Name: "ktsivkov",
 			},
 			RowsAffected: 2,
@@ -63,29 +62,24 @@ func TestQuery(t *testing.T) {
 		}
 	})
 	t.Run("Unmarshal", func(t *testing.T) {
+		type User struct {
+			Name string
+			gorm.Model
+		}
 		marshalled := "{\"Dest\":{\"Name\":\"ktsivkov\",\"ID\":0,\"CreatedAt\":\"0001-01-01T00:00:00Z\",\"UpdatedAt\":\"0001-01-01T00:00:00Z\",\"DeletedAt\":null},\"RowsAffected\":2}"
-		expected := Query{
-			Dest: &struct {
-				Name string
-				gorm.Model
-			}{
+		expected := Query[User]{
+			Dest: User{
 				Name: "ktsivkov",
 			},
 			RowsAffected: 2,
 		}
-		query := Query{
-			Dest: &struct {
-				Name string
-				gorm.Model
-			}{},
-			RowsAffected: 0,
-		}
-		err := query.Unmarshal([]byte(marshalled))
+		var q Query[User]
+		err := q.Unmarshal([]byte(marshalled))
 		if err != nil {
 			t.Fatalf("Unmarshal resulted to an unexpected error. %v", err)
 		}
 
-		if !reflect.DeepEqual(expected, query) {
+		if !reflect.DeepEqual(expected, q) {
 			t.Fatalf("Unmarshal was expected to shape the query into the expected, but failed.")
 		}
 	})


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Implemented a mechanism to Marshal & Unmarshal the Query passed to the Cacher interface, in order to help the integration with external cache storage. i.e. Redis

### User Case Description

When using an external storage into which we store the cached results by a client we need a proper way to marshal and unmarshal the structures into something that can be transferred easily.
