### PR TITLE
Add context to Cacher inteface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-_This package is a fork of [github.com/go-gorm/caches/v2](https://github.com/go-gorm/caches) that includes a `context.Context` argument in its `Cacher` interface methods._
+_This package is a fork of [github.com/go-gorm/caches/v2](https://github.com/go-gorm/caches) with the addition of `GetContext` and `StoreContext` methods on the `Cacher` interface to allow access to the `context.Context` object of the query statement._
 
 # Gorm Caches
 
@@ -135,6 +135,7 @@ func main() {
 package main
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -165,7 +166,11 @@ func (c *dummyCacher) init() {
 	}
 }
 
-func (c *dummyCacher) Get(ctx context.Context, key string) *caches.Query {
+func (c *dummyCacher) Get(key string) {
+	return c.GetContext(context.Background(), key)
+}
+
+func (c *dummyCacher) GetContext(ctx context.Context, key string) *caches.Query {
 	c.init()
 	val, ok := c.store.Load(key)
 	if !ok {
@@ -175,7 +180,11 @@ func (c *dummyCacher) Get(ctx context.Context, key string) *caches.Query {
 	return val.(*caches.Query)
 }
 
-func (c *dummyCacher) Store(ctx context.Context, key string, val *caches.Query) error {
+func (c *dummyCacher) Store(key string, val *caches.Query) error {
+    return c.StoreContext(context.Background(), key, val)
+}
+
+func (c *dummyCacher) StoreContext(ctx context.Context, key string, val *caches.Query) error {
 	c.init()
 	c.store.Store(key, val)
 	return nil

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+_This package is a fork of [github.com/go-gorm/caches/v2](https://github.com/go-gorm/caches) that includes a `context.Context` argument in its `Cacher` interface methods._
+
 # Gorm Caches
 
 Gorm Caches plugin using database request reductions (easer), and response caching mechanism provide you an easy way to optimize database performance.
@@ -163,7 +165,7 @@ func (c *dummyCacher) init() {
 	}
 }
 
-func (c *dummyCacher) Get(key string) *caches.Query {
+func (c *dummyCacher) Get(ctx context.Context, key string) *caches.Query {
 	c.init()
 	val, ok := c.store.Load(key)
 	if !ok {
@@ -173,7 +175,7 @@ func (c *dummyCacher) Get(key string) *caches.Query {
 	return val.(*caches.Query)
 }
 
-func (c *dummyCacher) Store(key string, val *caches.Query) error {
+func (c *dummyCacher) Store(ctx context.Context, key string, val *caches.Query) error {
 	c.init()
 	c.store.Store(key, val)
 	return nil

--- a/cacher.go
+++ b/cacher.go
@@ -3,6 +3,8 @@ package caches
 import "context"
 
 type Cacher interface {
-	Get(ctx context.Context, key string) *Query
-	Store(ctx context.Context, key string, val *Query) error
+	Get(key string) *Query
+	GetContext(ctx context.Context, key string) *Query
+	Store(key string, val *Query) error
+	StoreContext(ctx context.Context, key string, val *Query) error
 }

--- a/cacher.go
+++ b/cacher.go
@@ -1,6 +1,8 @@
 package caches
 
+import "context"
+
 type Cacher interface {
-	Get(key string) *Query
-	Store(key string, val *Query) error
+	Get(ctx context.Context, key string) *Query
+	Store(ctx context.Context, key string, val *Query) error
 }

--- a/cacher_test.go
+++ b/cacher_test.go
@@ -15,8 +15,11 @@ func (c *cacherMock) init() {
 		c.store = &sync.Map{}
 	}
 }
+func (c *cacherMock) Get(key string) *Query {
+	return c.GetContext(context.Background(), key)
+}
 
-func (c *cacherMock) Get(ctx context.Context, key string) *Query {
+func (c *cacherMock) GetContext(ctx context.Context, key string) *Query {
 	c.init()
 	val, ok := c.store.Load(key)
 	if !ok {
@@ -26,7 +29,11 @@ func (c *cacherMock) Get(ctx context.Context, key string) *Query {
 	return val.(*Query)
 }
 
-func (c *cacherMock) Store(ctx context.Context, key string, val *Query) error {
+func (c *cacherMock) Store(key string, val *Query) error {
+	return c.StoreContext(context.Background(), key, val)
+}
+
+func (c *cacherMock) StoreContext(ctx context.Context, key string, val *Query) error {
 	c.init()
 	c.store.Store(key, val)
 	return nil
@@ -42,7 +49,11 @@ func (c *cacherStoreErrorMock) init() {
 	}
 }
 
-func (c *cacherStoreErrorMock) Get(ctx context.Context, key string) *Query {
+func (c *cacherStoreErrorMock) Get(key string) *Query {
+	return c.GetContext(context.Background(), key)
+}
+
+func (c *cacherStoreErrorMock) GetContext(ctx context.Context, key string) *Query {
 	c.init()
 	val, ok := c.store.Load(key)
 	if !ok {
@@ -52,6 +63,10 @@ func (c *cacherStoreErrorMock) Get(ctx context.Context, key string) *Query {
 	return val.(*Query)
 }
 
-func (c *cacherStoreErrorMock) Store(context.Context, string, *Query) error {
+func (c *cacherStoreErrorMock) Store(key string, query *Query) error {
+	return c.StoreContext(context.Background(), key, query)
+}
+
+func (c *cacherStoreErrorMock) StoreContext(context.Context, string, *Query) error {
 	return errors.New("store-error")
 }

--- a/cacher_test.go
+++ b/cacher_test.go
@@ -1,6 +1,7 @@
 package caches
 
 import (
+	"context"
 	"errors"
 	"sync"
 )
@@ -15,7 +16,7 @@ func (c *cacherMock) init() {
 	}
 }
 
-func (c *cacherMock) Get(key string) *Query {
+func (c *cacherMock) Get(ctx context.Context, key string) *Query {
 	c.init()
 	val, ok := c.store.Load(key)
 	if !ok {
@@ -25,7 +26,7 @@ func (c *cacherMock) Get(key string) *Query {
 	return val.(*Query)
 }
 
-func (c *cacherMock) Store(key string, val *Query) error {
+func (c *cacherMock) Store(ctx context.Context, key string, val *Query) error {
 	c.init()
 	c.store.Store(key, val)
 	return nil
@@ -41,7 +42,7 @@ func (c *cacherStoreErrorMock) init() {
 	}
 }
 
-func (c *cacherStoreErrorMock) Get(key string) *Query {
+func (c *cacherStoreErrorMock) Get(ctx context.Context, key string) *Query {
 	c.init()
 	val, ok := c.store.Load(key)
 	if !ok {
@@ -51,6 +52,6 @@ func (c *cacherStoreErrorMock) Get(key string) *Query {
 	return val.(*Query)
 }
 
-func (c *cacherStoreErrorMock) Store(string, *Query) error {
+func (c *cacherStoreErrorMock) Store(context.Context, string, *Query) error {
 	return errors.New("store-error")
 }

--- a/caches.go
+++ b/caches.go
@@ -96,7 +96,7 @@ func (c *Caches) ease(db *gorm.DB, identifier string) {
 
 func (c *Caches) checkCache(db *gorm.DB, identifier string) bool {
 	if c.Conf.Cacher != nil {
-		if res := c.Conf.Cacher.Get(identifier); res != nil {
+		if res := c.Conf.Cacher.Get(db.Statement.Context, identifier); res != nil {
 			res.replaceOn(db)
 			return true
 		}
@@ -106,7 +106,7 @@ func (c *Caches) checkCache(db *gorm.DB, identifier string) bool {
 
 func (c *Caches) storeInCache(db *gorm.DB, identifier string) {
 	if c.Conf.Cacher != nil {
-		err := c.Conf.Cacher.Store(identifier, &Query{
+		err := c.Conf.Cacher.Store(db.Statement.Context, identifier, &Query{
 			Dest:         db.Statement.Dest,
 			RowsAffected: db.Statement.RowsAffected,
 		})

--- a/caches.go
+++ b/caches.go
@@ -96,7 +96,7 @@ func (c *Caches) ease(db *gorm.DB, identifier string) {
 
 func (c *Caches) checkCache(db *gorm.DB, identifier string) bool {
 	if c.Conf.Cacher != nil {
-		if res := c.Conf.Cacher.Get(db.Statement.Context, identifier); res != nil {
+		if res := c.Conf.Cacher.GetContext(db.Statement.Context, identifier); res != nil {
 			res.replaceOn(db)
 			return true
 		}
@@ -106,7 +106,7 @@ func (c *Caches) checkCache(db *gorm.DB, identifier string) bool {
 
 func (c *Caches) storeInCache(db *gorm.DB, identifier string) {
 	if c.Conf.Cacher != nil {
-		err := c.Conf.Cacher.Store(db.Statement.Context, identifier, &Query{
+		err := c.Conf.Cacher.StoreContext(db.Statement.Context, identifier, &Query{
 			Dest:         db.Statement.Dest,
 			RowsAffected: db.Statement.RowsAffected,
 		})

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-gorm/caches/v2
+module github.com/mgdigital/gorm-cache/v2
 
 go 1.16
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [ ] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adds `GetContext` and `StoreContext` methods to the `Cacher` interface.

### User Case Description

- It would be idiomatic to pass a context to a blocking cache adapter such as Redis.
- I wish to explicitly mark queries as being cacheable. For this I add a value to the context object. I appreciate this is a controversial pattern but it is the simplest way to achieve this without support within Gorm itself.
