### PR TITLE
Implemented valueToString function used to generate the query identifier

### DIFF
--- a/identifier.go
+++ b/identifier.go
@@ -2,6 +2,8 @@ package caches
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 
 	"gorm.io/gorm/callbacks"
 
@@ -14,16 +16,39 @@ func buildIdentifier(db *gorm.DB) string {
 	// Build query identifier,
 	//	for that reason we need to compile all arguments into a string
 	//	and concat them with the SQL query itself
-
 	callbacks.BuildQuerySQL(db)
-	var (
-		identifier string
-		query      string
-		queryArgs  string
-	)
-	query = db.Statement.SQL.String()
-	queryArgs = fmt.Sprintf("%v", db.Statement.Vars)
-	identifier = fmt.Sprintf("%s%s-%s", IdentifierPrefix, query, queryArgs)
-
+	query := db.Statement.SQL.String()
+	queryArgs := valueToString(db.Statement.Vars)
+	identifier := fmt.Sprintf("%s%s-%s", IdentifierPrefix, query, queryArgs)
 	return identifier
+}
+
+func valueToString(value interface{}) string {
+	valueOf := reflect.ValueOf(value)
+	switch valueOf.Kind() {
+	case reflect.Ptr:
+		if valueOf.IsNil() {
+			return "<nil>"
+		}
+		return valueToString(valueOf.Elem().Interface())
+	case reflect.Map:
+		var sb strings.Builder
+		sb.WriteString("{")
+		for i, key := range valueOf.MapKeys() {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(fmt.Sprintf("%s: %s", valueToString(key.Interface()), valueToString(valueOf.MapIndex(key).Interface())))
+		}
+		sb.WriteString("}")
+		return sb.String()
+	case reflect.Slice:
+		valueSlice := make([]interface{}, valueOf.Len())
+		for i := range valueSlice {
+			valueSlice[i] = valueToString(valueOf.Index(i).Interface())
+		}
+		return fmt.Sprintf("%v", valueSlice)
+	default:
+		return fmt.Sprintf("%v", value)
+	}
 }

--- a/identifier_test.go
+++ b/identifier_test.go
@@ -18,3 +18,38 @@ func Test_buildIdentifier(t *testing.T) {
 		t.Errorf("buildIdentifier expected to return `%s` but got `%s`", expected, actual)
 	}
 }
+
+func Test_sliceToString(t *testing.T) {
+	expected := "[test-val test-val 1 1 true true [test-val] [1] [true] [test-val] [1] [true] [test-val] [1] [true] [test-val] [1] [true] {test-val: test-val} {1: 1} {true: true} {test-val: test-val} {1: 1} {true: true} {test-val: test-val} {1: 1} {true: true} {test-val: test-val} {1: 1} {true: true}]"
+
+	strVal := "test-val"
+	intVal := 1
+	boolVal := true
+	sliceOfStr := []string{strVal}
+	sliceOfInt := []int{intVal}
+	sliceOfBool := []bool{boolVal}
+	sliceOfPointerStr := []*string{&strVal}
+	sliceOfPointerInt := []*int{&intVal}
+	sliceOfPointerBool := []*bool{&boolVal}
+	mapOfStr := map[string]string{strVal: strVal}
+	mapOfInt := map[int]int{intVal: intVal}
+	mapOfBool := map[bool]bool{boolVal: boolVal}
+	mapOfPointerStr := map[*string]*string{&strVal: &strVal}
+	mapOfPointerInt := map[*int]*int{&intVal: &intVal}
+	mapOfPointerBool := map[*bool]*bool{&boolVal: &boolVal}
+	actual := valueToString([]interface{}{
+		strVal, &strVal, intVal, // Primitives
+		&intVal, boolVal, &boolVal, // Pointer passed primitives
+		sliceOfStr, sliceOfInt, sliceOfBool, // Slices of primitives
+		&sliceOfStr, &sliceOfInt, &sliceOfBool, // Pointer passed slices of primitives
+		sliceOfPointerStr, sliceOfPointerInt, sliceOfPointerBool, // Slices of pointer primitives
+		&sliceOfPointerStr, &sliceOfPointerInt, &sliceOfPointerBool, // Pointer passed slices of pointer primitives
+		mapOfStr, mapOfInt, mapOfBool, // Map of primitives
+		mapOfPointerStr, mapOfPointerInt, mapOfPointerBool, // Map of pointer primitives
+		&mapOfStr, &mapOfInt, &mapOfBool, // Map of primitives
+		&mapOfPointerStr, &mapOfPointerInt, &mapOfPointerBool, // Map of pointer primitives
+	})
+	if expected != actual {
+		t.Errorf("sliceToString expected to return `%s` but got `%s`", expected, actual)
+	}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Implemented valueToString function for internal use.
Used to generate query identifier taking into account pointer passed values.
Ref #12 

### User Case Description

When the arguments for a query are passed by pointer they were previously hashed as pointers, now they are going to be addressed as values